### PR TITLE
Fix migration to drop custom ENUM types on downgrade

### DIFF
--- a/alembic/versions/92f8daac04aa_create_phases_tasks_and_attachments_.py
+++ b/alembic/versions/92f8daac04aa_create_phases_tasks_and_attachments_.py
@@ -166,4 +166,6 @@ def downgrade() -> None:
     op.drop_table("tasks")
     op.drop_index(op.f("ix_phases_id"), table_name="phases")
     op.drop_table("phases")
+    op.execute("DROP TYPE IF EXISTS taskstatus CASCADE")
+    op.execute("DROP TYPE IF EXISTS filetype CASCADE")
     # ### end Alembic commands ###


### PR DESCRIPTION
This pull request updates the Alembic migration script to ensure proper cleanup of custom PostgreSQL types during downgrade operations. The main change is the addition of commands to drop the `taskstatus` and `filetype` types if they exist, preventing potential issues when rolling back the migration.

Database schema cleanup:

* Added `DROP TYPE IF EXISTS` statements for the `taskstatus` and `filetype` PostgreSQL types in the `downgrade` function to ensure these custom types are removed during a downgrade.