### PR TITLE
Fix the bibliography search functionality by increasing the token limit and implement robust analysis of multi-part responses in the AI service

### DIFF
--- a/app/core/ai_config.py
+++ b/app/core/ai_config.py
@@ -126,7 +126,7 @@ FEATURE_GENERATION_CONFIG: dict[AIFeature, dict[str, float | int]] = {
     },
     AIFeature.BIBLIOGRAPHY: {
         "temperature": 0.5,  # Moderada para búsqueda estructurada
-        "max_output_tokens": 4096,  # Múltiples fuentes
+        "max_output_tokens": 8192,  # Múltiples fuentes y espacio para razonamiento
     },
 }
 

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -395,7 +395,18 @@ class AIService:
                 contents=prompt,
                 config=config,
             )
-            if not response.text:
+
+            response_text = ""
+            if (
+                response.candidates
+                and response.candidates[0].content
+                and response.candidates[0].content.parts
+            ):
+                for part in response.candidates[0].content.parts:
+                    if getattr(part, "text", None):
+                        response_text += part.text
+
+            if not response_text:
                 raise AIServiceError("No se recibió respuesta del modelo para búsqueda")
 
             # Extraer metadata de Grounding (URLs reales verificadas)
@@ -411,7 +422,7 @@ class AIService:
                     "No se recibió grounding_metadata, intentando parsear respuesta de texto"
                 )
                 # Fallback: intentar parsear la respuesta como JSON
-                sources = self._parse_text_sources(response.text, max_results)
+                sources = self._parse_text_sources(response_text, max_results)
 
             logger.info(
                 f"Búsqueda bibliográfica completada con {model_name} (Grounding activado), {len(sources)} fuentes encontradas"


### PR DESCRIPTION
This pull request enhances the bibliography search feature by increasing the output token limit for bibliography-related AI tasks and improving the way responses from the AI model are parsed. The changes ensure that more comprehensive results can be generated and that the service can handle different response formats from the AI model more robustly.

**Bibliography Feature Improvements:**

* Increased the `max_output_tokens` for the `BIBLIOGRAPHY` AI feature from 4096 to 8192, allowing for longer and more detailed responses from the AI model.

**AI Response Parsing Enhancements:**

* Updated the bibliography search logic to extract and concatenate text from all parts of the AI response, ensuring that multi-part responses are handled correctly.
* Modified the fallback parsing step to use the newly constructed `response_text` instead of the previous `response.text`, improving compatibility with the new response structure.