### PR TITLE
Add Attachment Replacement Support for Projects, Phases, and Tasks

### DIFF
--- a/app/api/api_v1/endpoints/phases.py
+++ b/app/api/api_v1/endpoints/phases.py
@@ -60,6 +60,34 @@ async def upload_document(
         raise
 
 
+@router.put("/{phase_id}/documentos", response_model=AttachmentResponse)
+async def replace_document(
+    *,
+    db: Session = Depends(get_db),
+    phase_id: int,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+) -> AttachmentResponse:
+    """
+    Reemplazar el documento adjunto de la fase.
+
+    Solo el propietario del proyecto al que pertenece la fase puede reemplazar el documento.
+    """
+    try:
+        document = attachment_service.replace_attachment(
+            db=db,
+            file=file,
+            parent_type="phase",
+            parent_id=phase_id,
+            user_id=current_user.id,  # type: ignore
+        )
+
+        return AttachmentResponse.model_validate(document)
+
+    except Exception:
+        raise
+
+
 @router.get("/{phase_id}/documentos")
 async def get_phase_document(
     *,

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 
 from app.core.dependencies import get_current_user
 from app.database import get_db
+from app.models.project import Project
 from app.models.user import User
 from app.schemas.attachment import AttachmentResponse
 from app.schemas.project import (
@@ -155,7 +156,7 @@ async def list_user_projects_by_search(
     db: Session = Depends(get_db),
     query: Optional[str] = None,
     current_user: User = Depends(get_current_user),
-) -> List[ProjectListResponse]:
+) -> List[type[ProjectListResponse]]:
     """
     Listar todos los proyectos del usuario autenticado que coincidan con la búsqueda.
 

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -97,6 +97,34 @@ async def upload_document(
         raise
 
 
+@router.put("/{project_id}/documentos", response_model=AttachmentResponse)
+async def replace_document(
+    *,
+    db: Session = Depends(get_db),
+    project_id: int,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+) -> AttachmentResponse:
+    """
+    Reemplazar el documento adjunto del proyecto.
+
+    Solo el propietario del proyecto puede reemplazar el documento.
+    """
+    try:
+        document = attachment_service.replace_attachment(
+            db=db,
+            file=file,
+            parent_type="project",
+            parent_id=project_id,
+            user_id=current_user.id,  # type: ignore
+        )
+
+        return AttachmentResponse.model_validate(document)
+
+    except Exception:
+        raise
+
+
 @router.get("/", response_model=List[ProjectListResponse])
 def list_projects(
     *,

--- a/app/api/api_v1/endpoints/tasks.py
+++ b/app/api/api_v1/endpoints/tasks.py
@@ -71,6 +71,34 @@ async def upload_document(
         raise
 
 
+@router.put("/{task_id}/documentos", response_model=AttachmentResponse)
+async def replace_document(
+    *,
+    db: Session = Depends(get_db),
+    task_id: int,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+) -> AttachmentResponse:
+    """
+    Reemplazar el documento adjunto de la tarea.
+
+    Solo el propietario del proyecto al que pertenece la tarea puede reemplazar el documento.
+    """
+    try:
+        document = attachment_service.replace_attachment(
+            db=db,
+            file=file,
+            parent_type="task",
+            parent_id=task_id,
+            user_id=current_user.id,  # type: ignore
+        )
+
+        return AttachmentResponse.model_validate(document)
+
+    except Exception:
+        raise
+
+
 @router.get("/{task_id}/documentos")
 async def get_task_document(
     *,

--- a/app/services/attachment_service.py
+++ b/app/services/attachment_service.py
@@ -269,10 +269,10 @@ class AttachmentService(BaseService[Attachment, AttachmentCreate, AttachmentUpda
         Raises:
             HTTPException: Si hay errores de validación o permisos
         """
-        # Validar que la entidad padre existe y pertenece al usuario
+        # 1. Validar que la entidad padre existe y pertenece al usuario
         self._validate_parent_entity(db, parent_type, parent_id, user_id)
 
-        # Obtener el adjunto existente
+        # 2. Obtener el adjunto existente
         existing_attachment = self.attachment_repository.get_attachment_by_parent(
             db, parent_id, parent_type
         )
@@ -283,27 +283,73 @@ class AttachmentService(BaseService[Attachment, AttachmentCreate, AttachmentUpda
                 detail=f"No existe un documento adjunto para esta {parent_type}",
             )
 
-        # Eliminar el adjunto existente
-        old_file_path = existing_attachment.file_path
-        attachment_id = existing_attachment.id
+        # 3. Obtener información del archivo y validar tipo/tamaño
+        filename, file_size, content_type = FileUtils.get_file_info(file)
 
+        # Validar tipo de archivo
         try:
-            # Crear el nuevo adjunto
-            new_attachment = self.create_attachment(
-                db, file, parent_type, parent_id, user_id
+            file_type = FileUtils.validate_file_type(file)
+        except FileValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        # Validar tamaño del archivo
+        try:
+            FileUtils.validate_file_size(file_size)
+        except FileValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        # 4. Generar nombre único y construir ruta para el nuevo archivo
+        unique_filename = FileUtils.generate_unique_filename(filename)
+        parent_type_plural = self._get_parent_type_plural(parent_type)
+        new_file_path = FileUtils.build_file_path(
+            parent_type_plural, parent_id, unique_filename
+        )
+
+        # Asegurar que el directorio existe
+        FileUtils.ensure_upload_directory()
+
+        # 5. Guardar nuevo archivo en ruta única
+        try:
+            self._save_file(file, new_file_path)
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Error al guardar el archivo: {str(e)}"
             )
 
-            # Eliminar el registro anterior
-            self.attachment_repository.remove(db, id=attachment_id)  # type: ignore
+        # Guardamos la ruta anterior para eliminarla después del commit
+        old_file_path = str(existing_attachment.file_path)
 
-            # Eliminar el archivo anterior después de crear el nuevo
-            FileUtils.delete_file(str(old_file_path))
+        # 6. Actualizar el mismo registro del adjunto (file_name, file_path, file_type, file_size)
+        existing_attachment.file_name = filename
+        existing_attachment.file_path = new_file_path
+        existing_attachment.file_type = file_type
+        existing_attachment.file_size = file_size
 
-            return new_attachment
+        # 7. Commit; si falla, borrar el nuevo archivo y rollback
+        try:
+            db.add(existing_attachment)
+            db.commit()
+            db.refresh(existing_attachment)
         except Exception as e:
-            # Si falla, mantener el adjunto anterior
+            # Eliminar el nuevo archivo que acabamos de guardar
+            FileUtils.delete_file(new_file_path)
             db.rollback()
-            raise e
+            print(f"Error al actualizar el registro del adjunto: {str(e)}")
+            raise HTTPException(
+                status_code=500,
+                detail="Error al actualizar el registro del adjunto",
+            )
+
+        # 8. Luego de commit, borrar el archivo anterior
+        try:
+            FileUtils.delete_file(old_file_path)
+        except Exception as e:
+            # No fallamos la petición si no se puede borrar el archivo anterior físico, pero lo logueamos.
+            print(
+                f"Advertencia: No se pudo eliminar el archivo anterior {old_file_path}: {e}"
+            )
+
+        return existing_attachment
 
     def _validate_parent_entity(
         self, db: Session, parent_type: str, parent_id: int, user_id: int

--- a/app/services/attachment_service.py
+++ b/app/services/attachment_service.py
@@ -341,12 +341,10 @@ class AttachmentService(BaseService[Attachment, AttachmentCreate, AttachmentUpda
             )
 
         # 8. Luego de commit, borrar el archivo anterior
-        try:
-            FileUtils.delete_file(old_file_path)
-        except Exception as e:
+        if not FileUtils.delete_file(old_file_path):
             # No fallamos la petición si no se puede borrar el archivo anterior físico, pero lo logueamos.
             print(
-                f"Advertencia: No se pudo eliminar el archivo anterior {old_file_path}: {e}"
+                f"Advertencia: No se pudo eliminar el archivo anterior {old_file_path}"
             )
 
         return existing_attachment

--- a/app/services/attachment_service.py
+++ b/app/services/attachment_service.py
@@ -59,7 +59,7 @@ class AttachmentService(BaseService[Attachment, AttachmentCreate, AttachmentUpda
             )
 
         # Obtener información del archivo
-        filename, file_size, content_type = FileUtils.get_file_info(file)
+        filename, file_size, _ = FileUtils.get_file_info(file)
 
         # Validar tipo de archivo
         try:
@@ -284,7 +284,7 @@ class AttachmentService(BaseService[Attachment, AttachmentCreate, AttachmentUpda
             )
 
         # 3. Obtener información del archivo y validar tipo/tamaño
-        filename, file_size, content_type = FileUtils.get_file_info(file)
+        filename, file_size, _ = FileUtils.get_file_info(file)
 
         # Validar tipo de archivo
         try:

--- a/tests/test_api/test_attachments.py
+++ b/tests/test_api/test_attachments.py
@@ -617,3 +617,194 @@ class TestAttachmentEndpoints:
         assert project_doc.json()["file_name"] == "project.pdf"
         assert phase_doc.json()["file_name"] == "phase.pdf"
         assert task_doc.json()["file_name"] == "task.pdf"
+
+    def test_replace_project_document_success(self):
+        """Probar reemplazo exitoso de documento en proyecto"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+
+        # 1. Subir primer documento
+        file_data1 = self.create_test_pdf_file("original.pdf")
+        response1 = client.post(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+        assert response1.status_code == 201
+        doc1 = response1.json()
+
+        # 2. Reemplazar documento
+        file_data2 = self.create_test_pdf_file("replaced.pdf")
+        response2 = client.put(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response2.status_code == 200
+        doc2 = response2.json()
+
+        # 3. Validar
+        assert doc2["file_name"] == "replaced.pdf"
+        assert doc2["id"] == doc1["id"]  # Debe mantener el mismo registro
+
+        # 4. Verificar obtención
+        response3 = client.get(
+            f"/api/v1/proyectos/{project['id']}/documentos", headers=headers
+        )
+        assert response3.status_code == 200
+        assert response3.json()["file_name"] == "replaced.pdf"
+
+    def test_replace_phase_document_success(self):
+        """Probar reemplazo exitoso de documento en fase"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+
+        # 1. Subir primer documento
+        file_data1 = self.create_test_pdf_file("original_phase.pdf")
+        response1 = client.post(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+        assert response1.status_code == 201
+        doc1 = response1.json()
+
+        # 2. Reemplazar documento
+        file_data2 = self.create_test_pdf_file("replaced_phase.pdf")
+        response2 = client.put(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response2.status_code == 200
+        doc2 = response2.json()
+
+        # 3. Validar
+        assert doc2["file_name"] == "replaced_phase.pdf"
+        assert doc2["id"] == doc1["id"]
+
+    def test_replace_task_document_success(self):
+        """Probar reemplazo exitoso de documento en tarea"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+        task = self.create_test_task(headers, phase["id"])
+
+        # 1. Subir primer documento
+        file_data1 = self.create_test_pdf_file("original_task.pdf")
+        response1 = client.post(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+        assert response1.status_code == 201
+        doc1 = response1.json()
+
+        # 2. Reemplazar documento
+        file_data2 = self.create_test_pdf_file("replaced_task.pdf")
+        response2 = client.put(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response2.status_code == 200
+        doc2 = response2.json()
+
+        # 3. Validar
+        assert doc2["file_name"] == "replaced_task.pdf"
+        assert doc2["id"] == doc1["id"]
+
+    def test_replace_document_not_found(self):
+        """Probar error 404 al intentar reemplazar sin adjunto previo"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+
+        file_data = self.create_test_pdf_file("replaced.pdf")
+        response = client.put(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers,
+            files={"file": file_data},
+        )
+        assert response.status_code == 404
+        assert "No existe un documento adjunto" in response.json()["detail"]
+
+    def test_replace_document_permission_denied(self):
+        """Probar error 403 al intentar reemplazar documento de otro usuario"""
+        # Usuario 1 crea proyecto y sube documento
+        headers1, _ = self.create_test_user_and_login(
+            "user1@example.com", "+573001234991"
+        )
+        project = self.create_test_project(headers1)
+
+        file_data1 = self.create_test_pdf_file("original.pdf")
+        client.post(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers1,
+            files={"file": file_data1},
+        )
+
+        # Usuario 2 intenta reemplazarlo
+        headers2, _ = self.create_test_user_and_login(
+            "user2@example.com", "+573001234992"
+        )
+        file_data2 = self.create_test_pdf_file("replaced.pdf")
+        response = client.put(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers2,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 403
+
+    def test_replace_document_invalid_type(self):
+        """Probar error 400 al reemplazar con tipo de archivo inválido"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+
+        # Subir original
+        file_data1 = self.create_test_pdf_file("original.pdf")
+        client.post(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+
+        # Reemplazar con txt inválido
+        file_data2 = self.create_test_invalid_file("invalid.txt")
+        response = client.put(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 400
+        assert "Tipo de archivo no permitido" in response.json()["detail"]
+
+    @patch("app.utils.file_utils.FileUtils.validate_file_size")
+    def test_replace_document_file_too_large(self, mock_validate_size):
+        """Probar error 400 al reemplazar con archivo muy grande"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+
+        # Subir original
+        file_data1 = self.create_test_pdf_file("original.pdf")
+        client.post(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+
+        # Reemplazar con archivo grande simula error
+        from app.utils.file_utils import FileValidationError
+
+        mock_validate_size.side_effect = FileValidationError(
+            "El archivo es demasiado grande"
+        )
+
+        file_data2 = self.create_test_pdf_file("large.pdf")
+        response = client.put(
+            f"/api/v1/proyectos/{project['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 400
+        assert "demasiado grande" in response.json()["detail"]

--- a/tests/test_api/test_attachments.py
+++ b/tests/test_api/test_attachments.py
@@ -808,3 +808,191 @@ class TestAttachmentEndpoints:
         )
         assert response.status_code == 400
         assert "demasiado grande" in response.json()["detail"]
+
+    def test_replace_phase_document_not_found(self):
+        """Probar error 404 en fase al reemplazar sin adjunto previo"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+
+        file_data = self.create_test_pdf_file("replaced_phase.pdf")
+        response = client.put(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers,
+            files={"file": file_data},
+        )
+        assert response.status_code == 404
+        assert "No existe un documento adjunto" in response.json()["detail"]
+
+    def test_replace_phase_document_permission_denied(self):
+        """Probar error 403 en fase al reemplazar documento de otro usuario"""
+        headers1, _ = self.create_test_user_and_login(
+            "phase_user1@example.com", "+573001234993"
+        )
+        project = self.create_test_project(headers1)
+        phase = self.create_test_phase(headers1, project["id"])
+
+        file_data1 = self.create_test_pdf_file("original_phase.pdf")
+        client.post(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers1,
+            files={"file": file_data1},
+        )
+
+        headers2, _ = self.create_test_user_and_login(
+            "phase_user2@example.com", "+573001234994"
+        )
+        file_data2 = self.create_test_pdf_file("replaced_phase.pdf")
+        response = client.put(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers2,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 403
+
+    def test_replace_phase_document_invalid_type(self):
+        """Probar error 400 en fase al reemplazar con tipo inválido"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+
+        file_data1 = self.create_test_pdf_file("original_phase.pdf")
+        client.post(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+
+        file_data2 = self.create_test_invalid_file("invalid_phase.txt")
+        response = client.put(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 400
+        assert "Tipo de archivo no permitido" in response.json()["detail"]
+
+    @patch("app.utils.file_utils.FileUtils.validate_file_size")
+    def test_replace_phase_document_file_too_large(self, mock_validate_size):
+        """Probar error 400 en fase al reemplazar con archivo muy grande"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+
+        file_data1 = self.create_test_pdf_file("original_phase.pdf")
+        client.post(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+
+        from app.utils.file_utils import FileValidationError
+
+        mock_validate_size.side_effect = FileValidationError(
+            "El archivo es demasiado grande"
+        )
+
+        file_data2 = self.create_test_pdf_file("large_phase.pdf")
+        response = client.put(
+            f"/api/v1/fases/{phase['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 400
+        assert "demasiado grande" in response.json()["detail"]
+
+    def test_replace_task_document_not_found(self):
+        """Probar error 404 en tarea al reemplazar sin adjunto previo"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+        task = self.create_test_task(headers, phase["id"])
+
+        file_data = self.create_test_pdf_file("replaced_task.pdf")
+        response = client.put(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers,
+            files={"file": file_data},
+        )
+        assert response.status_code == 404
+        assert "No existe un documento adjunto" in response.json()["detail"]
+
+    def test_replace_task_document_permission_denied(self):
+        """Probar error 403 en tarea al reemplazar documento de otro usuario"""
+        headers1, _ = self.create_test_user_and_login(
+            "task_user1@example.com", "+573001234995"
+        )
+        project = self.create_test_project(headers1)
+        phase = self.create_test_phase(headers1, project["id"])
+        task = self.create_test_task(headers1, phase["id"])
+
+        file_data1 = self.create_test_pdf_file("original_task.pdf")
+        client.post(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers1,
+            files={"file": file_data1},
+        )
+
+        headers2, _ = self.create_test_user_and_login(
+            "task_user2@example.com", "+573001234996"
+        )
+        file_data2 = self.create_test_pdf_file("replaced_task.pdf")
+        response = client.put(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers2,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 403
+
+    def test_replace_task_document_invalid_type(self):
+        """Probar error 400 en tarea al reemplazar con tipo inválido"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+        task = self.create_test_task(headers, phase["id"])
+
+        file_data1 = self.create_test_pdf_file("original_task.pdf")
+        client.post(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+
+        file_data2 = self.create_test_invalid_file("invalid_task.txt")
+        response = client.put(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 400
+        assert "Tipo de archivo no permitido" in response.json()["detail"]
+
+    @patch("app.utils.file_utils.FileUtils.validate_file_size")
+    def test_replace_task_document_file_too_large(self, mock_validate_size):
+        """Probar error 400 en tarea al reemplazar con archivo muy grande"""
+        headers, user_id = self.create_test_user_and_login()
+        project = self.create_test_project(headers)
+        phase = self.create_test_phase(headers, project["id"])
+        task = self.create_test_task(headers, phase["id"])
+
+        file_data1 = self.create_test_pdf_file("original_task.pdf")
+        client.post(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers,
+            files={"file": file_data1},
+        )
+
+        from app.utils.file_utils import FileValidationError
+
+        mock_validate_size.side_effect = FileValidationError(
+            "El archivo es demasiado grande"
+        )
+
+        file_data2 = self.create_test_pdf_file("large_task.pdf")
+        response = client.put(
+            f"/api/v1/tareas/{task['id']}/documentos",
+            headers=headers,
+            files={"file": file_data2},
+        )
+        assert response.status_code == 400
+        assert "demasiado grande" in response.json()["detail"]

--- a/tests/test_services/test_attachment_service.py
+++ b/tests/test_services/test_attachment_service.py
@@ -423,37 +423,57 @@ class TestAttachmentService:
         assert "Error al eliminar el adjunto" in str(exc_info.value.detail)
         self.mock_db.rollback.assert_called_once()
 
-    def test_replace_attachment_success(self):
-        """Probar reemplazo exitoso de adjunto"""
-        mock_file = self.create_mock_upload_file()
+    @patch("app.services.attachment_service.FileUtils.get_file_info")
+    @patch("app.services.attachment_service.FileUtils.validate_file_type")
+    @patch("app.services.attachment_service.FileUtils.validate_file_size")
+    @patch("app.services.attachment_service.FileUtils.generate_unique_filename")
+    @patch("app.services.attachment_service.FileUtils.build_file_path")
+    @patch("app.services.attachment_service.FileUtils.ensure_upload_directory")
+    @patch("app.services.attachment_service.FileUtils.delete_file")
+    def test_replace_attachment_success(
+        self,
+        mock_delete,
+        mock_ensure_dir,
+        mock_build_path,
+        mock_unique_name,
+        mock_validate_size,
+        mock_validate_type,
+        mock_file_info,
+    ):
+        """Probar reemplazo exitoso de adjunto actualizando el mismo registro"""
+        mock_file = self.create_mock_upload_file(filename="new.pdf")
         mock_project = self.create_mock_project()
         old_attachment = self.create_mock_attachment()
-        new_attachment = self.create_mock_attachment(attachment_id=2)
+        old_attachment.file_path = "/uploads/documents/projects/1/old.pdf"
 
         self.service.project_repository.get = Mock(return_value=mock_project)
         self.service.attachment_repository.get_attachment_by_parent = Mock(
             return_value=old_attachment
         )
 
-        # Mock para create_attachment
-        self.service.create_attachment = Mock(return_value=new_attachment)
-        self.service.attachment_repository.remove = Mock(return_value=True)
+        # Configurar file utils
+        mock_file_info.return_value = ("new.pdf", 2048, "application/pdf")
+        mock_validate_type.return_value = FileType.PDF
+        mock_unique_name.return_value = "unique-new.pdf"
+        mock_build_path.return_value = "/uploads/documents/projects/1/unique-new.pdf"
 
-        with patch(
-            "app.services.attachment_service.FileUtils.delete_file"
-        ) as mock_delete:
-            result = self.service.replace_attachment(
-                self.mock_db, mock_file, "project", 1, 1
-            )
+        # Mock para _save_file
+        self.service._save_file = Mock()
 
-            assert result == new_attachment
-            self.service.create_attachment.assert_called_once_with(
-                self.mock_db, mock_file, "project", 1, 1
-            )
-            self.service.attachment_repository.remove.assert_called_once_with(
-                self.mock_db, id=old_attachment.id
-            )
-            mock_delete.assert_called_once_with(str(old_attachment.file_path))
+        result = self.service.replace_attachment(
+            self.mock_db, mock_file, "project", 1, 1
+        )
+
+        assert result == old_attachment
+        assert result.file_name == "new.pdf"
+        assert result.file_path == "/uploads/documents/projects/1/unique-new.pdf"
+        assert result.file_size == 2048
+
+        self.mock_db.add.assert_called_once_with(old_attachment)
+        self.mock_db.commit.assert_called_once()
+        self.mock_db.refresh.assert_called_once_with(old_attachment)
+        self.service._save_file.assert_called_once()
+        mock_delete.assert_called_once_with("/uploads/documents/projects/1/old.pdf")
 
     def test_replace_attachment_no_existing(self):
         """Probar reemplazo cuando no existe adjunto previo"""


### PR DESCRIPTION
This pull request introduces a new feature that allows users to replace existing documents attached to projects, phases, and tasks. It adds new API endpoints for document replacement, implements robust logic for safely updating attachments (including validation and file management), and provides comprehensive tests to ensure correct behavior and error handling.

**API Endpoints for Document Replacement:**

* Added `PUT` endpoints to replace documents for projects, phases, and tasks in `projects.py`, `phases.py`, and `tasks.py`, respectively. Only the project owner can perform replacements. [[1]](diffhunk://#diff-b9a61cc966334d62a5d1a0ce976db83927bcf8cf67a6b7870373bd613e8e70f8R100-R127) [[2]](diffhunk://#diff-65e2db58c5a759659f6406d4d78475be32d2327e683a88f88cba11bbaebf3a9bR63-R90) [[3]](diffhunk://#diff-b679fccf2566ea81251177de975ff695fd1caad6a5f2bfcdbf5425313b7c1d23R74-R101)

**Attachment Replacement Logic:**

* Refactored the `replace_attachment` method in `attachment_service.py` to:
  - Validate the existence and ownership of the parent entity.
  - Validate file type and size.
  - Generate a unique filename and ensure upload directory exists.
  - Save the new file, update the existing attachment record, commit the transaction, and delete the old file after a successful commit.
  - Handle errors gracefully, including rolling back and cleaning up files as needed. [[1]](diffhunk://#diff-7222063ef66828c1ad86ec04e5b75527213368a164c46bc205ede65fe16a0a2fL272-R275) [[2]](diffhunk://#diff-7222063ef66828c1ad86ec04e5b75527213368a164c46bc205ede65fe16a0a2fL286-R352)

**Testing:**

* Added end-to-end API tests for document replacement scenarios, including success cases, permission checks, invalid file types, oversized files, and missing previous attachments.
* Updated and expanded service-level tests for the attachment replacement logic, including mocks for file operations and database interactions.