### PR TITLE
feat: add optional position field to PhaseCreate schema and update tests

### DIFF
--- a/app/schemas/phase.py
+++ b/app/schemas/phase.py
@@ -46,6 +46,9 @@ class PhaseCreate(PhaseBase):
     """Esquema para crear una fase"""
 
     project_id: int = Field(..., description="ID del proyecto al que pertenece la fase")
+    position: Optional[int] = Field(  # type: ignore[assignment]
+        None, ge=0, description="Posición de la fase en el proyecto"
+    )
 
 
 class PhaseUpdate(BaseModel):

--- a/tests/test_schemas/test_phase.py
+++ b/tests/test_schemas/test_phase.py
@@ -145,6 +145,19 @@ class TestPhaseSchemas:
         assert phase.color == "#33FF57"
         assert phase.project_id == 123
 
+    def test_phase_create_without_position(self):
+        """Probar PhaseCreate sin especificar posición (debe ser opcional)"""
+        phase_data = {
+            "name": "Nueva Fase Sin Posición",
+            "project_id": 123,
+        }
+
+        phase = PhaseCreate(**phase_data)
+
+        assert phase.name == "Nueva Fase Sin Posición"
+        assert phase.position is None
+        assert phase.project_id == 123
+
     def test_phase_create_missing_project_id(self):
         """Probar PhaseCreate sin project_id requerido"""
         with pytest.raises(ValidationError) as exc_info:

--- a/tests/test_services/test_phase_service.py
+++ b/tests/test_services/test_phase_service.py
@@ -96,6 +96,38 @@ class TestPhaseService:
         assert result.position == 0  # type: ignore
         assert result.project_id == test_project.id
 
+    def test_create_phase_without_position(self, db_session, test_user, test_project):
+        """Probar creación exitosa de fase sin posición especificada (debe calcular posición automática)"""
+        # Crear primera fase con posición 0
+        phase1_data = PhaseCreate(
+            name="Primera Fase",
+            position=0,
+            project_id=test_project.id,
+            color=None,
+        )
+        phase_service.create_phase(
+            db=db_session,
+            phase_in=phase1_data,
+            owner_id=test_user.id,
+        )
+
+        # Crear segunda fase sin posición
+        phase2_data = PhaseCreate(
+            name="Segunda Fase",
+            project_id=test_project.id,
+            color=None,
+        )
+        result = phase_service.create_phase(
+            db=db_session,
+            phase_in=phase2_data,
+            owner_id=test_user.id,
+        )
+
+        assert result is not None
+        assert result.name == "Segunda Fase"  # type: ignore
+        assert result.position == 1  # Debe ser max_position (0) + 1 = 1
+        assert result.project_id == test_project.id
+
     def test_create_phase_project_not_found(self, db_session, test_user):
         """Probar creación de fase con proyecto inexistente"""
         phase_data = PhaseCreate(


### PR DESCRIPTION
This pull request introduces support for making the `position` field optional when creating a new phase, allowing the backend to automatically assign the correct position if it's not specified. The change is validated with new unit tests for both schema and service layers.

**Schema changes:**

* Made the `position` field in the `PhaseCreate` schema optional, allowing it to be omitted when creating a phase.

**Testing improvements:**

* Added a test to verify that `PhaseCreate` works correctly when `position` is not provided, confirming it defaults to `None`.
* Added a service layer test to ensure that creating a phase without specifying `position` results in the backend assigning the next available position automatically.