### PR TITLE
Refactor imports for performance and fix circular dependency handling

### DIFF
--- a/app/models/attachment.py
+++ b/app/models/attachment.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import CheckConstraint, DateTime
 from sqlalchemy import Enum as SqlEnum
@@ -8,9 +8,11 @@ from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.phase import Phase
-from app.models.project import Project
-from app.models.task import Task
+
+if TYPE_CHECKING:
+    from app.models.phase import Phase
+    from app.models.project import Project
+    from app.models.task import Task
 
 
 class FileType(str, Enum):

--- a/app/models/bibliography.py
+++ b/app/models/bibliography.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timezone
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.project import Project
+
+if TYPE_CHECKING:
+    from app.models.project import Project
 
 
 class Bibliography(Base):

--- a/app/models/conversation.py
+++ b/app/models/conversation.py
@@ -2,14 +2,16 @@
 Modelos para conversaciones de chat con IA
 """
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.project import Project
-from app.models.user import User
+
+if TYPE_CHECKING:
+    from app.models.project import Project
+    from app.models.user import User
 
 
 class Conversation(Base):

--- a/app/models/phase.py
+++ b/app/models/phase.py
@@ -1,12 +1,14 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.attachment import Attachment
-from app.models.project import Project
-from app.models.task import Task
+
+if TYPE_CHECKING:
+    from app.models.attachment import Attachment
+    from app.models.project import Project
+    from app.models.task import Task
 
 
 class Phase(Base):

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -1,16 +1,18 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.attachment import Attachment
-from app.models.bibliography import Bibliography
-from app.models.conversation import Conversation
-from app.models.phase import Phase
-from app.models.user import User
+
+if TYPE_CHECKING:
+    from app.models.attachment import Attachment
+    from app.models.bibliography import Bibliography
+    from app.models.conversation import Conversation
+    from app.models.phase import Phase
+    from app.models.user import User
 
 
 class ProjectStatus(str, Enum):

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime
 from sqlalchemy import Enum as SqlEnum
@@ -8,8 +8,10 @@ from sqlalchemy import ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.attachment import Attachment
-from app.models.phase import Phase
+
+if TYPE_CHECKING:
+    from app.models.attachment import Attachment
+    from app.models.phase import Phase
 
 
 class TaskStatus(str, Enum):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,12 +1,14 @@
 from datetime import datetime, timezone
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
-from app.models.conversation import Conversation
-from app.models.project import Project
+
+if TYPE_CHECKING:
+    from app.models.conversation import Conversation
+    from app.models.project import Project
 
 
 class User(Base):


### PR DESCRIPTION
This pull request refactors the import statements across several model files to improve type checking and prevent potential circular import issues. Specifically, it replaces direct imports of related models with imports inside an `if TYPE_CHECKING` block, ensuring these imports are only used for type hints and not at runtime.

Refactoring for type checking and import safety:

* Replaced direct imports of related models with `if TYPE_CHECKING` blocks in the following files to avoid circular dependencies and optimize runtime imports:
  - `app/models/attachment.py`
  - `app/models/bibliography.py`
  - `app/models/conversation.py`
  - `app/models/phase.py`
  - `app/models/project.py`
  - `app/models/task.py`
  - `app/models/user.py`