### PR TITLE
Update mock response structure for Google GenAI SDK compatibility

### DIFF
--- a/tests/test_services/test_ai_service.py
+++ b/tests/test_services/test_ai_service.py
@@ -277,6 +277,12 @@ class TestAIService:
             '[{"titulo": "Artículo 1", "autores": ["Smith"], "anio": 2020}]'
         )
 
+        # Para Google GenAI SDK ^1.0, el código del servicio revisa candidates[0].content.parts
+        mock_part = MagicMock()
+        mock_part.text = (
+            '[{"titulo": "Artículo 1", "autores": ["Smith"], "anio": 2020}]'
+        )
+
         # Mock de grounding metadata con soporte web
         mock_support = MagicMock()
         mock_support.uri = "https://example.com/article1"
@@ -286,8 +292,11 @@ class TestAIService:
         mock_grounding_support.web_search_queries = ["machine learning"]
         mock_grounding_support.grounding_supports = [mock_support]
 
-        mock_response.candidates = [MagicMock()]
-        mock_response.candidates[0].grounding_metadata = mock_grounding_support
+        mock_candidate = MagicMock()
+        mock_candidate.content.parts = [mock_part]
+        mock_candidate.grounding_metadata = mock_grounding_support
+
+        mock_response.candidates = [mock_candidate]
         mock_genai_client.models.generate_content.return_value = mock_response
 
         query = "machine learning in education"


### PR DESCRIPTION
This pull request updates the test for the AI service's bibliography search to better align with the Google GenAI SDK v1.0 interface. The changes ensure that the test accurately mocks the structure of the SDK's response, particularly the handling of candidate content parts.

Test mocking improvements for Google GenAI SDK v1.0:

* Updated the mock response in `test_search_bibliography_success` to use `candidates[0].content.parts` instead of directly assigning text, reflecting the SDK's expected response structure.
* Refactored the candidate mock to include the `parts` attribute and properly assign `grounding_metadata`, improving the accuracy of the test's simulation of real SDK responses.